### PR TITLE
Include callbacks

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,25 +3,27 @@ import os
 import re
 
 
-requirements = ['numpy', 'cma']
-if os.environ.get('READTHEDOCS') != 'True':
-    requirements.append('tensorflow>2.1*')
-PACKAGE = 'evolutionary_keras'
+requirements = ["numpy", "cma"]
+if os.environ.get("READTHEDOCS") != "True":
+    requirements.append("tensorflow>2.1*")
+PACKAGE = "evolutionary_keras"
 
 this_directory = os.path.abspath(os.path.dirname(__file__))
 with open(os.path.join(this_directory, "README.md"), encoding="utf-8") as f:
     long_description = f.read()
 
+
 def get_version():
     """ Gets the version from the package's __init__ file
     if there is some problem, let it happily fail """
-    VERSIONFILE = os.path.join('src', PACKAGE, '__init__.py')
-    initfile_lines = open(VERSIONFILE, 'rt').readlines()
+    VERSIONFILE = os.path.join("src", PACKAGE, "__init__.py")
+    initfile_lines = open(VERSIONFILE, "rt").readlines()
     VSRE = r"^__version__ = ['\"]([^'\"]*)['\"]"
     for line in initfile_lines:
         mo = re.search(VSRE, line, re.M)
         if mo:
             return mo.group(1)
+
 
 setup(
     name="evolutionary_keras",
@@ -33,12 +35,7 @@ setup(
     packages=find_packages("src"),
     zip_safe=False,
     install_requires=requirements,
-    extras_require={
-        'docs' : [
-        'sphinx_rtd_theme',
-        'recommonmark',
-        ],
-    },
+    extras_require={"docs": ["sphinx_rtd_theme", "recommonmark",],},
     python_requires=">=3.6",
     descriptions="An evolutionary algorithm implementation for Keras",
     long_description=long_description,

--- a/src/evolutionary_keras/models.py
+++ b/src/evolutionary_keras/models.py
@@ -112,29 +112,6 @@ class EvolModel(Model):
 
         return self.history_info
 
-    def genetic_fit(
-        self, x=None, y=None, validation_data=None, epochs=1, verbose=0, callbacks=None,
-    ):
-        if not isinstance(callbacks, callbacks_module.CallbackList):
-            callbacks = callbacks_module.CallbackList(
-                callbacks,
-                add_history=True,
-                add_progbar=False,
-                model=self,
-                verbose=verbose,
-                epochs=epochs,
-            )
-        callbacks.on_train_begin()
-
-        result = self.perform_genetic_fit(
-            x=x,
-            y=y,
-            epochs=epochs,
-            verbose=verbose,
-            validation_data=validation_data,
-            callbacks=callbacks,
-        )
-        return result
 
     def fit(
         self, x=None, y=None, validation_data=None, epochs=1, verbose=0, callbacks=None, **kwargs,
@@ -143,14 +120,27 @@ class EvolModel(Model):
         the given number of epochs.
         """
         if self.is_genetic:
-            result = self.genetic_fit(
+            # Container that configures and calls `tf.keras.Callback`s.
+            if not isinstance(callbacks, callbacks_module.CallbackList):
+                callbacks = callbacks_module.CallbackList(
+                    callbacks,
+                    add_history=True,
+                    add_progbar=False,
+                    model=self,
+                    verbose=verbose,
+                    epochs=epochs,
+                )
+            callbacks.on_train_begin()
+
+            result = self.perform_genetic_fit(
                 x=x,
                 y=y,
-                validation_data=validation_data,
                 epochs=epochs,
                 verbose=verbose,
+                validation_data=validation_data,
                 callbacks=callbacks,
             )
+
         else:
             result = super().fit(
                 x=x,

--- a/src/evolutionary_keras/models.py
+++ b/src/evolutionary_keras/models.py
@@ -112,13 +112,7 @@ class EvolModel(Model):
         return self.history_info
 
     def genetic_fit(
-        self,
-        x=None,
-        y=None,
-        validation_data=None,
-        epochs=1,
-        verbose=0,
-        callbacks=None,
+        self, x=None, y=None, validation_data=None, epochs=1, verbose=0, callbacks=None,
     ):
         if not isinstance(callbacks, callbacks_module.CallbackList):
             callbacks = callbacks_module.CallbackList(
@@ -141,7 +135,16 @@ class EvolModel(Model):
         )
         return result
 
-    def fit(self, x=None, y=None, validation_data=None, epochs=1, verbose=0, callbacks=None, **kwargs):
+    def fit(
+        self,
+        x=None,
+        y=None,
+        validation_data=None,
+        epochs=1,
+        verbose=0,
+        callbacks=None,
+        **kwargs,
+    ):
         """ If the optimizer is genetic, the fitting procedure consists on executing `run_step` for
         the given number of epochs.
         """
@@ -161,6 +164,7 @@ class EvolModel(Model):
                 validation_data=validation_data,
                 epochs=epochs,
                 verbose=verbose,
+                callbacks=callbacks,
                 **kwargs,
             )
         return result

--- a/src/evolutionary_keras/models.py
+++ b/src/evolutionary_keras/models.py
@@ -74,6 +74,7 @@ class EvolModel(Model):
         """
         # Prepare the history for the initial epoch
         self.history_info.on_train_begin()
+        callbacks.on_train_begin()
         # Validation data is currently not being used!!
         if validation_data is not None:
             log.warning(
@@ -88,6 +89,8 @@ class EvolModel(Model):
 
         epoch_logs = {}
         for epoch in range(epochs):
+            callbacks.on_epoch_begin(epoch=epoch)
+
             # Generate the best mutant
             score, best_mutant = self.opt_instance.run_step(x=x, y=y)
 

--- a/src/evolutionary_keras/models.py
+++ b/src/evolutionary_keras/models.py
@@ -85,7 +85,6 @@ class EvolModel(Model):
                 "The optimizer determines the number of generations, epochs will be ignored."
             )
 
-        epoch_logs = {}
         for epoch in range(epochs):
             callbacks.on_epoch_begin(epoch=epoch)
 
@@ -101,14 +100,13 @@ class EvolModel(Model):
                 information = f" > epoch: {epoch+1}/{epochs}, {loss} "
                 log.info(information)
 
-            epoch_logs.update(score)
-            callbacks.on_epoch_end(epoch=epoch, logs=epoch_logs)
+            callbacks.on_epoch_end(epoch=epoch, logs=score)
 
             # Fill keras history
             history_data = score
             self.history_info.on_epoch_end(epoch, history_data)
 
-        callbacks.on_train_end(logs=epoch_logs)
+        callbacks.on_train_end(logs=score)
 
         return self.history_info
 

--- a/src/evolutionary_keras/models.py
+++ b/src/evolutionary_keras/models.py
@@ -77,9 +77,7 @@ class EvolModel(Model):
         callbacks.on_train_begin()
         # Validation data is currently not being used!!
         if validation_data is not None:
-            log.warning(
-                "Validation data is not used at the moment by the Genetic Algorithms!!"
-            )
+            log.warning("Validation data is not used at the moment by the Genetic Algorithms!!")
 
         if isinstance(self.opt_instance, Evolutionary_Optimizers.CMA) and epochs != 1:
             epochs = 1
@@ -139,14 +137,7 @@ class EvolModel(Model):
         return result
 
     def fit(
-        self,
-        x=None,
-        y=None,
-        validation_data=None,
-        epochs=1,
-        verbose=0,
-        callbacks=None,
-        **kwargs,
+        self, x=None, y=None, validation_data=None, epochs=1, verbose=0, callbacks=None, **kwargs,
     ):
         """ If the optimizer is genetic, the fitting procedure consists on executing `run_step` for
         the given number of epochs.

--- a/src/evolutionary_keras/optimizers.py
+++ b/src/evolutionary_keras/optimizers.py
@@ -10,7 +10,7 @@ import numpy as np
 from tensorflow.keras.optimizers import Optimizer
 
 from evolutionary_keras.utilities import compatibility_numpy, get_number_nodes
-
+# from evolutionary_keras.utilities import get_number_nodes
 
 class EvolutionaryStrategies(Optimizer):
     """ Parent class for all Evolutionary Strategies
@@ -122,8 +122,9 @@ class NGA(EvolutionaryStrategies):
         # TODO: eventually we should save here a reference to the layer and their
         # corresponding weights, since the nodes are the output of the layer
         # and the weights the corresponding to that layer
-        for layer in self.model.layers:
-            self.n_nodes += get_number_nodes(layer)
+        for layer in range(1, len(weight_shapes), 2):
+            self.n_nodes += weight_shapes[layer][0]
+
         # TODO related to previous TODO: non trianable weights should not be important
         self.non_training_weights = self.model.non_trainable_weights
         return weight_shapes

--- a/src/evolutionary_keras/optimizers.py
+++ b/src/evolutionary_keras/optimizers.py
@@ -73,14 +73,7 @@ class NGA(EvolutionaryStrategies):
 
     # In case the user wants to adjust sigma_init
     # population_size or mutation_rate parameters the NGA method has to be initiated
-    def __init__(
-        self,
-        name="NGA",
-        sigma_init=15,
-        population_size=80,
-        mutation_rate=0.05,
-        **kwargs
-    ):
+    def __init__(self, name="NGA", sigma_init=15, population_size=80, mutation_rate=0.05, **kwargs):
         self.sigma_init = sigma_init
         self.population_size = population_size
         self.mutation_rate = mutation_rate
@@ -115,7 +108,7 @@ class NGA(EvolutionaryStrategies):
         # Get trainable weight from the model and their shapes
         trainable_weights = self.model.trainable_weights
         weight_shapes = [weight.shape.as_list() for weight in trainable_weights]
-        self.n_nodes += get_number_nodes(self.model)
+        self.n_nodes = get_number_nodes(self.model)
         return weight_shapes
 
     def create_mutants(self, change_both_wb=True):
@@ -153,17 +146,13 @@ class NGA(EvolutionaryStrategies):
                 # Mutate weights and biases by adding values from random distributions
                 sigma_eff = self.sigma * (self.n_generations ** (-np.random.rand()))
                 if change_both_wb:
-                    randn_mutation = sigma_eff * np.random.randn(
-                        self.shape[layer - 1][0]
-                    )
+                    randn_mutation = sigma_eff * np.random.randn(self.shape[layer - 1][0])
                     mutant[layer - 1][:, node_in_layer] += randn_mutation
                     mutant[layer][node_in_layer] += sigma_eff * np.random.randn()
                 else:
                     change_weight = np.random.randint(2, dtype="bool")
                     if change_weight:
-                        randn_mutation = sigma_eff * np.random.randn(
-                            self.shape[layer - 1][0]
-                        )
+                        randn_mutation = sigma_eff * np.random.randn(self.shape[layer - 1][0])
                         mutant[layer - 1][:, node_in_layer] += randn_mutation
                     else:
                         mutant[layer][node_in_layer] += sigma_eff * np.random.randn()
@@ -295,9 +284,7 @@ class CMA(EvolutionaryStrategies):
 
     def get_shape(self):
         # we do all this to keep track of the position of the trainable weights
-        self.trainable_weights_names = [
-            weights.name for weights in self.model.trainable_weights
-        ]
+        self.trainable_weights_names = [weights.name for weights in self.model.trainable_weights]
 
         if self.trainable_weights_names == []:
             raise TypeError("The model does not have any trainable weights!")
@@ -314,8 +301,7 @@ class CMA(EvolutionaryStrategies):
         # The first values of 'self.length_flat_layer' is set to 0 which is helpful in determining
         # the range of weights in the function 'undo_flatten'.
         self.length_flat_layer = [
-            len(np.reshape(weight.numpy(), [-1]))
-            for weight in self.model.trainable_weights
+            len(np.reshape(weight.numpy(), [-1])) for weight in self.model.trainable_weights
         ]
         self.length_flat_layer.insert(0, 0)
 
@@ -350,9 +336,7 @@ class CMA(EvolutionaryStrategies):
             ]
             new_weights.append(np.reshape(flat_layer, layer_shape))
 
-        ordered_names = [
-            weight.name for layer in self.model.layers for weight in layer.weights
-        ]
+        ordered_names = [weight.name for layer in self.model.layers for weight in layer.weights]
 
         new_parent = deepcopy(self.model.get_weights())
         for i, weight in enumerate(self.trainable_weights_names):

--- a/src/evolutionary_keras/optimizers.py
+++ b/src/evolutionary_keras/optimizers.py
@@ -108,26 +108,31 @@ class NGA(EvolutionaryStrategies):
         # Get trainable weight from the model and their shapes
         trainable_weights = self.model.trainable_weights
         weight_shapes = [weight.shape.as_list() for weight in trainable_weights]
+        weights = [weight for weight in trainable_weights]
         self.n_nodes = get_number_nodes(self.model)
 
         # check compatibility of the shape with the NGA optimizer
         NNshape = None
         count_nodes = 0
-        for num, layer_shape in enumerate(weight_shapes):
+        for num, layer in enumerate(weights):
+            layer_shape = layer.shape.as_list()
             num += 1
             if num % 2 == 0:
                 count_nodes += np.array(layer_shape)
                 if np.array(layer_shape).size != 1:
-                    NNshape = "incompatible"
+                    raise ValueError(
+                        f"The NGA optimizer expects a (weight-bias)\N{SUPERSCRIPT LATIN SMALL LETTER N} architecture, {layer.name} does not satisfy this condition"
+                    )
             else:
                 if np.array(layer_shape).size != 2:
-                    NNshape = "incompatible"
+                    raise ValueError(
+                        f"The NGA optimizer expects a (weight-bias)\N{SUPERSCRIPT LATIN SMALL LETTER N} architecture, {layer.name} does not satisfy this condition"
+                    )
         if count_nodes != self.n_nodes:
-            NNshape = "incompatible"
-        if NNshape == "incompatible":
             raise ValueError(
-                "Using the NGA optimizer requires the network to have a (weight-bias)^n structure, with 1-dimensional bias"
+                "The number of nodes with a bias attribute differs from the number of trainable nodes found based on the architecture of the trainable weights."
             )
+
         return weight_shapes
 
     def create_mutants(self, change_both_wb=True):
@@ -255,7 +260,7 @@ class CMA(EvolutionaryStrategies):
         population_size=None,
         max_evaluations=None,
         verbosity=1,
-        **kwargs
+        **kwargs,
     ):
         """
         `CMA` does not allow the user to set a number of generations (epochs),

--- a/src/evolutionary_keras/optimizers.py
+++ b/src/evolutionary_keras/optimizers.py
@@ -125,7 +125,7 @@ class NGA(EvolutionaryStrategies):
             NNshape = "incompatible"
         if NNshape == "incompatible":
             raise ValueError(
-                "Using the NGA optimizer requires the network to have a $(weight-bias)^n$ structure, with 1-dimensional bias"
+                "Using the NGA optimizer requires the network to have a (weight-bias)^n structure, with 1-dimensional bias"
             )
 
         return weight_shapes

--- a/src/evolutionary_keras/optimizers.py
+++ b/src/evolutionary_keras/optimizers.py
@@ -112,7 +112,6 @@ class NGA(EvolutionaryStrategies):
         self.n_nodes = get_number_nodes(self.model)
 
         # check compatibility of the shape with the NGA optimizer
-        NNshape = None
         count_nodes = 0
         for num, layer in enumerate(weights):
             layer_shape = layer.shape.as_list()

--- a/src/evolutionary_keras/optimizers.py
+++ b/src/evolutionary_keras/optimizers.py
@@ -111,15 +111,16 @@ class NGA(EvolutionaryStrategies):
         self.n_nodes = get_number_nodes(self.model)
 
         # check compatibility of the shape with the NGA optimizer
+        NNshape = None
+        count_nodes = 0
         for num, layer_shape in enumerate(weight_shapes):
-            count_nodes = 0
             num += 1
-            if num % 1 == 0:
-                if np.array(layer_shape).size != 2:
-                    NNshape = "incompatible"
             if num % 2 == 0:
-                count_nodes += np.array(layer_shape).size
+                count_nodes += np.array(layer_shape)
                 if np.array(layer_shape).size != 1:
+                    NNshape = "incompatible"
+            else:
+                if np.array(layer_shape).size != 2:
                     NNshape = "incompatible"
         if count_nodes != self.n_nodes:
             NNshape = "incompatible"
@@ -127,7 +128,6 @@ class NGA(EvolutionaryStrategies):
             raise ValueError(
                 "Using the NGA optimizer requires the network to have a (weight-bias)^n structure, with 1-dimensional bias"
             )
-
         return weight_shapes
 
     def create_mutants(self, change_both_wb=True):

--- a/src/evolutionary_keras/optimizers.py
+++ b/src/evolutionary_keras/optimizers.py
@@ -109,6 +109,25 @@ class NGA(EvolutionaryStrategies):
         trainable_weights = self.model.trainable_weights
         weight_shapes = [weight.shape.as_list() for weight in trainable_weights]
         self.n_nodes = get_number_nodes(self.model)
+
+        # check compatibility of the shape with the NGA optimizer
+        for num, layer_shape in enumerate(weight_shapes):
+            count_nodes = 0
+            num += 1
+            if num % 1 == 0:
+                if np.array(layer_shape).size != 2:
+                    NNshape = "incompatible"
+            if num % 2 == 0:
+                count_nodes += np.array(layer_shape).size
+                if np.array(layer_shape).size != 1:
+                    NNshape = "incompatible"
+        if count_nodes != self.n_nodes:
+            NNshape = "incompatible"
+        if NNshape == "incompatible":
+            raise ValueError(
+                "Using the NGA optimizer requires the network to have a $(weight-bias)^n$ structure, with 1-dimensional bias"
+            )
+
         return weight_shapes
 
     def create_mutants(self, change_both_wb=True):

--- a/src/evolutionary_keras/tests/test_utilities.py
+++ b/src/evolutionary_keras/tests/test_utilities.py
@@ -1,20 +1,20 @@
-# """ Test the utilities of evolutionary_keras """
+""" Test the utilities of evolutionary_keras """
 
-# from tensorflow.keras.layers import Dense, Input
+from tensorflow.keras.layers import Dense, Input
 
-# from evolutionary_keras.utilities import get_number_nodes
-# from evolutionary_keras.models import EvolModel
+from evolutionary_keras.utilities import get_number_nodes
+from evolutionary_keras.models import EvolModel
 
 
-# def test_get_number_nodes():
-#     """ Get the number of nodes of a layer """
+def test_get_number_nodes():
+    """ Get the number of nodes of a layer """
 
-#     nodes = 10
+    nodes = 10
 
-#     # Tensorflow won't build the layer until it is called in a model
-#     input_layer = Input(shape=(1,))
-#     output_layer = Dense(units=nodes, name="test_layer")
-#     modelito = EvolModel(input_layer, output_layer(input_layer))
+    # Tensorflow won't build the layer until it is called in a model
+    input_layer = Input(shape=(1,))
+    output_layer = Dense(units=nodes, name="test_layer")
+    modelito = EvolModel(input_layer, output_layer(input_layer))
 
-#     # Check that indeed the number of nodes is parsed correctly
-#     assert nodes == get_number_nodes(output_layer)
+    # Check that indeed the number of nodes is parsed correctly
+    assert nodes == get_number_nodes(modelito)

--- a/src/evolutionary_keras/tests/test_utilities.py
+++ b/src/evolutionary_keras/tests/test_utilities.py
@@ -6,15 +6,15 @@ from evolutionary_keras.utilities import get_number_nodes
 from evolutionary_keras.models import EvolModel
 
 
-def test_get_number_nodes():
-    """ Get the number of nodes of a layer """
+# def test_get_number_nodes():
+#     """ Get the number of nodes of a layer """
 
-    nodes = 10
+#     nodes = 10
 
-    # Tensorflow won't build the layer until it is called in a model
-    input_layer = Input(shape=(1,))
-    output_layer = Dense(units=nodes, name="test_layer")
-    modelito = EvolModel(input_layer, output_layer(input_layer))
+#     # Tensorflow won't build the layer until it is called in a model
+#     input_layer = Input(shape=(1,))
+#     output_layer = Dense(units=nodes, name="test_layer")
+#     modelito = EvolModel(input_layer, output_layer(input_layer))
 
-    # Check that indeed the number of nodes is parsed correctly
-    assert nodes == get_number_nodes(output_layer)
+#     # Check that indeed the number of nodes is parsed correctly
+#     assert nodes == get_number_nodes(output_layer)

--- a/src/evolutionary_keras/tests/test_utilities.py
+++ b/src/evolutionary_keras/tests/test_utilities.py
@@ -1,9 +1,9 @@
-""" Test the utilities of evolutionary_keras """
+# """ Test the utilities of evolutionary_keras """
 
-from tensorflow.keras.layers import Dense, Input
+# from tensorflow.keras.layers import Dense, Input
 
-from evolutionary_keras.utilities import get_number_nodes
-from evolutionary_keras.models import EvolModel
+# from evolutionary_keras.utilities import get_number_nodes
+# from evolutionary_keras.models import EvolModel
 
 
 # def test_get_number_nodes():

--- a/src/evolutionary_keras/utilities.py
+++ b/src/evolutionary_keras/utilities.py
@@ -2,18 +2,24 @@
     Module including some useful functions
 """
 from tensorflow.keras import backend as K
+from tensorflow.keras import Model
 
 
-def get_number_nodes(layer):
+def get_number_nodes(model):
     """ Given a keras layer, outputs the number of nodes """
     nodes = 0
-    # It is necessary to check whether the layer is trainable
-    # AND whether it has any weights which is trainable
-    if layer.trainable and layer.trainable_weights:
-        # The first dimension is always the batch size so
-        # this is a good proxy for the number of nodes
-        output_nodes = layer.get_output_shape_at(0)[1:]
-        nodes = sum(output_nodes)
+    for layer in model.layers:
+        # It is necessary to check whether the layer is trainable
+        # AND whether it has any weights which is trainable
+        if layer.trainable and layer.trainable_weights:
+            if isinstance(layer, Model):
+                nodes += get_number_nodes(layer)
+            elif hasattr(layer, "bias"):
+                nodes += layer.bias.shape[0]
+            else:
+                raise ValueError(
+                    "The NGA optimizer can only be applied to model layers with 'bias' attribute"
+                )
     return nodes
 
 


### PR DESCRIPTION
I had to include the processing of callbacks. 

Also, we used `get_number_nodes` to get the number of nodes in each layer, currently the pdf model is considered a single layer and the output nodes are  always 14, so I went back to relying on the weight-bias structure which we still use later on anyway. 

The conda package should be updated as well, this is what causes CI to fail at https://github.com/NNPDF/nnpdf/pull/737.